### PR TITLE
Prevent segmentation fault when destructor is called and open() hasn't been invoked

### DIFF
--- a/Fasta.cpp
+++ b/Fasta.cpp
@@ -241,8 +241,10 @@ void FastaReference::open(string reffilename) {
 }
 
 FastaReference::~FastaReference(void) {
-    fclose(file);
-    delete index;
+    if (file != NULL)
+      fclose(file);
+    if (index != NULL)
+      delete index;
 }
 
 string FastaReference::getSequence(string seqname) {

--- a/Fasta.h
+++ b/Fasta.h
@@ -62,7 +62,10 @@ class FastaReference {
         void open(string reffilename);
         bool usingmmap;
         string filename;
-        FastaReference(void) : usingmmap(false) { }
+        FastaReference(void) : usingmmap(false) {
+	  file  = NULL;
+	  index = NULL;
+	}
         ~FastaReference(void);
         FILE* file;
         void* filemm;


### PR DESCRIPTION
Resolves issue #6 