### PR TITLE
Allow control over compile commands and add staged install targets to Makefile

### DIFF
--- a/LargeFileSupport.h
+++ b/LargeFileSupport.h
@@ -5,7 +5,7 @@
 #define ftell64(a)     _ftelli64(a)
 #define fseek64(a,b,c) _fseeki64(a,b,c)
 typedef __int64 off_type;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #define ftell64(a)     ftello(a)
 #define fseek64(a,b,c) fseeko(a,b,c)
 typedef off_t off_type;

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,33 @@
 
 # Use ?= to allow overriding from the env or command-line
 CXX ?=		g++
-CFLAGS ?=	-O3
+CXXFLAGS ?=	-O3
 PREFIX ?=	./stage
 STRIP_CMD ?=	strip
 INSTALL ?=	install -c
 MKDIR ?=	mkdir -p
 
 # Required flags that we shouldn't override
-CFLAGS +=	-D_FILE_OFFSET_BITS=64
+CXXFLAGS +=	-D_FILE_OFFSET_BITS=64
 
 OBJS =	Fasta.o FastaHack.o split.o disorder.o
 
 all:	fastahack
 
 fastahack: $(OBJS)
-	$(CXX) $(CFLAGS) $(OBJS) -o fastahack
+	$(CXX) $(CXXFLAGS) $(OBJS) -o fastahack
 
 FastaHack.o: Fasta.h FastaHack.cpp
-	$(CXX) $(CFLAGS) -c FastaHack.cpp
+	$(CXX) $(CXXFLAGS) -c FastaHack.cpp
 
 Fasta.o: Fasta.h Fasta.cpp
-	$(CXX) $(CFLAGS) -c Fasta.cpp
+	$(CXX) $(CXXFLAGS) -c Fasta.cpp
 
 split.o: split.h split.cpp
-	$(CXX) $(CFLAGS) -c split.cpp
+	$(CXX) $(CXXFLAGS) -c split.cpp
 
 disorder.o: disorder.c disorder.h
-	$(CXX) $(CFLAGS) -c disorder.c
+	$(CXX) $(CXXFLAGS) -c disorder.c
 
 install: fastahack
 	$(MKDIR) $(DESTDIR)$(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
-CXX=g++
-CFLAGS=-O3 -D_FILE_OFFSET_BITS=64
 
-fastahack: Fasta.o FastaHack.cpp split.o disorder.o
-	$(CXX) $(CFLAGS) Fasta.o FastaHack.cpp split.o disorder.o -o fastahack
+# Use ?= to allow overriding from the env or command-line
+CXX ?=		g++
+CFLAGS ?=	-O3
+
+# Required flags that we shouldn't override
+CFLAGS +=	-D_FILE_OFFSET_BITS=64
+
+OBJS =	Fasta.o FastaHack.o split.o disorder.o
+
+fastahack: $(OBJS)
+	$(CXX) $(CFLAGS) $(OBJS) -o fastahack
+
+FastaHack.o: Fasta.h FastaHack.cpp
+	$(CXX) $(CFLAGS) -c FastaHack.cpp
 
 Fasta.o: Fasta.h Fasta.cpp
 	$(CXX) $(CFLAGS) -c Fasta.cpp

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 CXX ?=		g++
 CFLAGS ?=	-O3
 PREFIX ?=	./stage
+STRIP_CMD ?=	strip
+INSTALL ?=	install -c
+MKDIR ?=	mkdir -p
 
 # Required flags that we shouldn't override
 CFLAGS +=	-D_FILE_OFFSET_BITS=64
@@ -27,8 +30,11 @@ disorder.o: disorder.c disorder.h
 	$(CXX) $(CFLAGS) -c disorder.c
 
 install: fastahack
-	install -d ${DESTDIR}${PREFIX}/bin
-	install -c fastahack ${DESTDIR}${PREFIX}/bin
+	$(MKDIR) $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) fastahack $(DESTDIR)$(PREFIX)/bin
+
+install-strip: install
+	$(STRIP_CMD) $(DESTDIR)$(PREFIX)/bin/fastahack
 
 clean:
 	rm -rf fastahack *.o stage

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@
 # Use ?= to allow overriding from the env or command-line
 CXX ?=		g++
 CFLAGS ?=	-O3
+PREFIX ?=	./stage
 
 # Required flags that we shouldn't override
 CFLAGS +=	-D_FILE_OFFSET_BITS=64
 
 OBJS =	Fasta.o FastaHack.o split.o disorder.o
+
+all:	fastahack
 
 fastahack: $(OBJS)
 	$(CXX) $(CFLAGS) $(OBJS) -o fastahack
@@ -23,7 +26,11 @@ split.o: split.h split.cpp
 disorder.o: disorder.c disorder.h
 	$(CXX) $(CFLAGS) -c disorder.c
 
+install: fastahack
+	install -d ${DESTDIR}${PREFIX}/bin
+	install -c fastahack ${DESTDIR}${PREFIX}/bin
+
 clean:
-	rm -f fastahack *.o
+	rm -rf fastahack *.o stage
 
 .PHONY: clean


### PR DESCRIPTION

These changes are more extensive than the previous pull requests.

I added example install and install-strip targets to facilitate the creation of packages such as
Debian packages, FreeBSD ports, MacPorts, etc.  With a Makefile like this, creating the package manager framework will be trivial.  ( They supply variables like CXX by default. )

Default behavior of the Makefile should still be the same.
