### PR TITLE
Add missing return statement

### DIFF
--- a/Fasta.cpp
+++ b/Fasta.cpp
@@ -87,6 +87,7 @@ ostream& operator<<(ostream& output, FastaIndex& fastaIndex) {
     for( vector<FastaIndexEntry>::iterator fit = sortedIndex.begin(); fit != sortedIndex.end(); ++fit) {
         output << *fit << endl;
     }
+    return output;
 }
 
 void FastaIndex::indexReference(string refname) {


### PR DESCRIPTION
Without this, we get weird `basic_string::_M_construct null not valid` `logic_error`s on GCC 8.1.